### PR TITLE
unify the default sally configurations

### DIFF
--- a/doc/sally.cfg
+++ b/doc/sally.cfg
@@ -1,6 +1,6 @@
 #
 # Example configuration for Sally
-# Copyright (C) 2011 Konrad Rieck (konrad@mlsec.org)
+# Copyright (C) 2011-2012 Konrad Rieck (konrad@mlsec.org)
 # --
 # A detailed description of all configuration parameters is provided
 # in the manual page of Sally, see sally(1).
@@ -10,46 +10,46 @@
 input = {
     # Input format.
     # Supported types: "dir", "arc", "lines", "fasta"
-    input_format = "lines";
+    input_format = "dir";
 
     # Number of strings to process in each chunk
-    chunk_size = 256;
+    chunk_size = 1024;
 
     # Decode strings using URI encoding (%XX)
     decode_str = 0;
 
     # Regex for extracting labels from FASTA descriptions
-    fasta_regex = " (\\+|-)?[0-9]+";
+    fasta_regex = " (\\+|-)[:digit:]*";
 
     # Regex for extracting labels from text lines
-    lines_regex = "^(\\+|-)?[0-9]+";
+    lines_regex = "[:digit:]+: ";
 };
 
 # Feature configuration
 features = {
     # Length of n-grams.
-    ngram_len = 4;
+    ngram_len = 2;
 
     # Delimiters for n-grams. An empty string triggers byte n-grams.
-    ngram_delim = "";
+    ngram_delim = "%0a%0d%20";
 
     # Positional n-grams instead of regular n-grams.
     ngram_pos = 0;
 
     # Sorted n-grams (n-perms) instead of regular n-grams.
-    ngram_sort = 1;
+    ngram_sort = 0;
 
     # Embedding mode for vectors. Supported types "cnt", "bin", "tfidf"
     vect_embed = "cnt";
 
     # Normalization mode for vectors. Supported types "l1", "l2", "none".
-    vect_norm = "none";
+    vect_norm = "l1";
 
     # Signed embedding. Compensate hash collisions by a signed embedding.
     vect_sign = 0;
 
     # Number of hash bits to use with dimensions = 2 ^ hash_bits
-    hash_bits = 22;
+    hash_bits = 26;
 
     # Explicit hash table instead of hashing features only.
     explicit_hash = 0;


### PR DESCRIPTION
In Sally there are two sources of default settings that contain different configuration values:
1) doc/sally.cfg which gets (of course depending on the installation directory) copied to e.g. /usr/local/etc/
2) the values encoded in src/sconfig.c

This branch syncs those two "duplicates".

I would suggest not to keep those duplicates in future versions. Personally I would prefer to completely remove the functionality of (1). The reason is that if one processes a batch of data with Sally, she probably defines the configuration anyways in a script. However, if one is only firing up Sally once in a while the potential is high to have some old configuration in ~/.sally or .../etc/ that leads to unexpected behavior.
