### PR TITLE
fix the length specifier of the percent decoded input strings

### DIFF
--- a/src/input/input.c
+++ b/src/input/input.c
@@ -128,10 +128,10 @@ void input_preproc(string_t *strs, int len)
 
     config_lookup_int(&cfg, "input.decode_str", &decode);
 
-    for (j = 0; j < len; j++) {
-        if (decode) {
-            /* After decoding some bytes are wasted in memory :( */
-            decode_str(strs[j].str);
+    if (decode) {
+        for (j = 0; j < len; j++) {
+            strs[j].len = decode_str(strs[j].str);
+            strs[j].str = (char*) realloc(strs[j].str, strs[j].len);
         }
     }
 }


### PR DESCRIPTION
When using the --decode_str program option Sally "inline replaces" the percent encoded characters in the input string. However, the length of the new string is not written to the internal data struct. Hence this results in  two many n-grams whereas the last ones are obviously wrong or at least one bad last word n-gram.
