### PR TITLE
Count the number of lines rather than the number of newline characters

### DIFF
--- a/src/input/input.c
+++ b/src/input/input.c
@@ -128,10 +128,10 @@ void input_preproc(string_t *strs, int len)
 
     config_lookup_int(&cfg, "input.decode_str", &decode);
 
-    if (decode) {
-        for (j = 0; j < len; j++) {
-            strs[j].len = decode_str(strs[j].str);
-            strs[j].str = (char*) realloc(strs[j].str, strs[j].len);
+    for (j = 0; j < len; j++) {
+        if (decode) {
+            /* After decoding some bytes are wasted in memory :( */
+            decode_str(strs[j].str);
         }
     }
 }


### PR DESCRIPTION
input_lines_open(.) function is supposed to return the number of input samples. In case of the "lines" input mode this refers to the number of lines. The function rather counts the number of newlines. Hence, it might be off-by-one if the last line doesn't end with a newline character.
gzgetline correctly reads these last lines as well. Therefore, this issue bug is only related to the progress indicator and for input files that only contain a single line that doesn't end with a newline character. In the latter case that single line is not recognized/ processed.

Update: Instead of branching from master I branched from 'decodedstr_length'. The relevant commit is the one with the id 5602577....
