### PR TITLE
strip newline characters at the end of each line of the input file

### DIFF
--- a/src/input/input_lines.c
+++ b/src/input/input_lines.c
@@ -1,6 +1,6 @@
 /*
  * Sally - A Tool for Embedding Strings in Vector Spaces
- * Copyright (C) 2010 Konrad Rieck (konrad@mlsec.org)
+ * Copyright (C) 2010-2012 Konrad Rieck (konrad@mlsec.org)
  * --
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -116,9 +116,13 @@ int input_lines_open(char *name)
 int input_lines_read(string_t *strs, int len)
 {
     assert(strs && len > 0);
-    int read, i = 0, j = 0;
+    int read, i = 0, j = 0, k = 0;
     size_t size;
     char buf[32], *line = NULL;
+
+    static char strip[256] = {0};
+    strip[(int) '\n'] = 1;
+    strip[(int) '\r'] = 1;
 
     for (i = 0; i < len; i++) {
         line = NULL;
@@ -128,10 +132,23 @@ int input_lines_read(string_t *strs, int len)
             break;
         }
 
-        if (strlen(line) == 0) {
-            line_num++;
-            continue;
+        for (k = read -1; k >= 0; k--) {
+            if (!strip[(int) line[k]]) {
+                break;
+            }
         }
+        line[k +1] = 0x00;
+
+        // ATTENTION! Skipping a line means that at the end of the loop i != j
+        // Whereas i is the number of lines read and j would by the number of
+        // not empty lines processed. Hence, returning j would clash with the
+        // function's specification that defines the return value as the number
+        // of lines read.
+
+        // if (k < 0) {
+        //    line_num++;
+        //    continue;
+        // }
 
         strs[i].label = get_label(line);
         strs[j].str = line;
@@ -155,3 +172,4 @@ void input_lines_close()
 }
 
 /** @} */
+


### PR DESCRIPTION
When processing the input in "lines" mode the newline character at the end of each line remains part of the sample. This behavior comes from the way getline/ gzgetline is defined. However, for correctly processing the input, trailing newline characters need to be stripped. Otherwise, this newline character becomes part of the derived n-grams.

This patch/ branch also reveals another issue with the line-wise processing of the input. Since the input_lines module counts newlines (master) / lines ('num_lines' branch) rather than not empty lines, one cannot skip empty lines when embedding the input in vector space. Otherwise, the expected number of lines and the number of lines actually embedded would differ and Sally stops with a fatal error.
